### PR TITLE
set up Documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,41 @@
+name: Documentation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'release-'
+    tags: '*'
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Cache artifacts
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts 
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia --project=docs/ docs/make.jl

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -1,5 +1,6 @@
 # LeetCode in Julia - 用 Julia 编写力扣题目
 
+[![Documentation][docs-dev-img]][docs-dev-url]
 [![Unit Test][action-img]][action-url]
 [![Code Style: Blue][blue-img]][blue-url]
 
@@ -23,3 +24,5 @@
 [action-url]: https://github.com/JuliaCN/LeetCode.jl/actions
 [blue-img]: https://img.shields.io/badge/code%20style-blue-4495d1.svg
 [blue-url]: https://github.com/invenia/BlueStyle
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://github.com/JuliaCN/LeetCode.jl/latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # LeetCode
 
+[![Documentation][docs-dev-img]][docs-dev-url]
 [![Unit Test][action-img]][action-url]
 [![Code Style: Blue][blue-img]][blue-url]
 
@@ -22,3 +23,5 @@ A community driven project to provide solutions for LeetCode problems in the Jul
 [action-url]: https://github.com/JuliaCN/LeetCode.jl/actions
 [blue-img]: https://img.shields.io/badge/code%20style-blue-4495d1.svg
 [blue-url]: https://github.com/invenia/BlueStyle
+[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
+[docs-dev-url]: https://github.com/JuliaCN/LeetCode.jl/latest

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+/problems
+/Manifest.toml
+/build
+/src/democards

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+DemoCards = "311a05b2-6137-4a5a-b473-18580a3d38b5"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+LeetCode = "177aac61-66e1-4cb4-9340-6393b6c3fb4c"
+
+[compat]
+Documenter = "0.25"
+DemoCards = "0.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,41 @@
+using Documenter
+using DemoCards
+using JSON
+
+root = joinpath(@__DIR__, "..")
+page_root = joinpath(root, "docs", "problems")
+page_src = joinpath(root, "src", "problems")
+page_dest = joinpath(page_root, "id")
+
+# prepare page contents and page meta
+if isdir(page_root)
+    rm(page_root; force=true, recursive=true)
+end
+mkpath(page_root)
+cp(page_src, page_dest; force=true)
+rm(joinpath(page_dest, "problems.jl")) # no need to render this
+
+# provide a configuration file to tell DemoCards that we want to use number order instead
+# of string order
+open(joinpath(page_dest, "config.json"), "w") do io
+    files = filter(x->x!="config.json", readdir(page_dest))
+    sort!(files; by=x->parse(Int, split(x, ".")[1]))
+    JSON.print(io, Dict("title"=>"By ID", "order"=>files))
+end
+
+## build docs
+
+# 1. generate demo files
+demopage, postprocess_cb = makedemos("problems") # the relative path to docs/
+
+# 2. normal Documenter usage
+format = Documenter.HTML(prettyurls=get(ENV, "CI", nothing) == "true")
+makedocs(format = format,
+         pages = [
+            "Home" => "index.md",
+            demopage,
+         ],
+         sitename = "LeetCode")
+
+# 3. postprocess after makedocs
+postprocess_cb()

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+# LeetCode
+
+The solution set to LeetCode problems!


### PR DESCRIPTION
TLDR, it uses [DemoCards](https://github.com/johnnychen94/DemoCards.jl) to analyze and generate the page for each problem (saved in `docs/src/democards`), and then pass the generated pages to Documenter.

There're many warnings because Documenter could not understand the current python-style docstrings.


preview:

![image](https://user-images.githubusercontent.com/8684355/101048704-d004d200-35bd-11eb-9025-4e883824f68c.png)


closes #33