### PR TITLE
WIP: dynamically combining problems and solutions

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,7 +3,8 @@ DemoCards = "311a05b2-6137-4a5a-b473-18580a3d38b5"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LeetCode = "177aac61-66e1-4cb4-9340-6393b6c3fb4c"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 
 [compat]
-Documenter = "0.25"
 DemoCards = "0.3"
+Documenter = "0.25"

--- a/docs/generate_page.jl
+++ b/docs/generate_page.jl
@@ -1,0 +1,97 @@
+using DemoCards: democard
+using JSON
+using ProgressMeter
+
+# we assume that files are all named in "<id>.<title>" format
+get_id(filename::String) = parse(Int, split(filename, ".")[1])
+
+function generate_page(repo_root;
+        problems = joinpath("docs", "problems_raw"),
+        solutions = joinpath("src", "problems"),
+        tests = joinpath("test", "problems")
+)
+    # these are tracked by git
+    raw_problem_dir = joinpath(repo_root, problems)
+    raw_solution_dir = joinpath(repo_root, solutions)
+    raw_tests_dir = joinpath(repo_root, tests)
+
+    # where the problem and solution files are generated -- this won't be tracked by git
+    page_root = abspath(repo_root, "docs", "problems")
+    page_problem = abspath(page_root, "problem")
+    page_solution = abspath(page_root, "solution")
+
+    if isdir(page_root)
+        rm(page_root; force=true, recursive=true)
+    end
+    mkpath(page_solution)
+    mkpath(page_problem)
+
+    # 1. copy the whole solutions dir
+    cp(raw_solution_dir, page_solution; force=true)
+    rm(joinpath(page_solution, "problems.jl")) # no need to render this
+
+    # 2. modify solution file and generate problem file
+    raw_problem_filenames = filter(x->endswith(x, ".md"), readdir(raw_problem_dir))
+    raw_test_filenames = filter(x->endswith(x, ".jl"), readdir(raw_tests_dir))
+
+    @showprogress 1 "Combining problems, solutions and tests" for filename in readdir(page_solution)
+        @info "generate page" filename
+        if endswith(filename, ".jl")
+            id = get_id(filename)
+    
+            # 2.1. attract meta info from the md file
+            pid = findfirst(x->get_id(x)==id, raw_problem_filenames)
+            if isnothing(pid)
+                mdfile = joinpath(raw_problem_dir, splitext(filename)[1] * ".md")
+                @warn "$mdfile does not exist"
+                continue
+            end
+            raw_problem_file = joinpath(raw_problem_dir, raw_problem_filenames[pid])
+            card = democard(raw_problem_file)
+            title = card.title
+            author = card.author
+            date = card.date
+    
+            # 2.2 extract test codes; we assume everything in the testfile is needed
+            tid = findfirst(x->get_id(x)==id, raw_test_filenames)
+            raw_test_file = joinpath(raw_tests_dir, raw_test_filenames[tid])
+            test = read(raw_test_file)
+
+            # 2.2. dump the meta info and the test cases into jl file
+            solution_file = joinpath(page_solution, filename)
+            old = read(solution_file)
+            open(solution_file, "w") do io
+                println(io,
+                    "# ---\n",
+                    "# title: $title\n",
+                    "# id: problem$id\n",
+                    "# author: $author\n",
+                    "# date: $date\n",
+                    "# hidden: true\n",
+                    "# ---\n",
+                    "\n",
+                    "using LeetCode, Test\n",
+                )
+                write(io, old)
+                println(io, "\n# ---\n")
+                write(io, test)
+            end
+    
+            # 2.3. add the url link to solution
+            problem_file = joinpath(page_problem, basename(raw_problem_file))
+            cp(raw_problem_file, problem_file)
+            open(problem_file, "a") do io
+                println(io, "[![Solution](https://img.shields.io/badge/Check-solution-blue)](@ref problem$id)")
+            end
+        end
+    end
+
+    # 3. tell
+    open(joinpath(page_solution, "config.json"), "w") do io
+        files = filter(x->x!="config.json", readdir(page_solution))
+        sort!(files; by=get_id)
+        JSON.print(io, Dict("title"=>"Solution", "order"=>files))
+    end
+
+    return page_root
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,32 +1,14 @@
 using Documenter
 using DemoCards
-using JSON
 
-root = joinpath(@__DIR__, "..")
-page_root = joinpath(root, "docs", "problems")
-page_src = joinpath(root, "src", "problems")
-page_dest = joinpath(page_root, "id")
+include("generate_page.jl")
 
-# prepare page contents and page meta
-if isdir(page_root)
-    rm(page_root; force=true, recursive=true)
-end
-mkpath(page_root)
-cp(page_src, page_dest; force=true)
-rm(joinpath(page_dest, "problems.jl")) # no need to render this
-
-# provide a configuration file to tell DemoCards that we want to use number order instead
-# of string order
-open(joinpath(page_dest, "config.json"), "w") do io
-    files = filter(x->x!="config.json", readdir(page_dest))
-    sort!(files; by=x->parse(Int, split(x, ".")[1]))
-    JSON.print(io, Dict("title"=>"By ID", "order"=>files))
-end
+page = generate_page(joinpath(@__DIR__, ".."); solutions="src/problems_tmp")
 
 ## build docs
 
 # 1. generate demo files
-demopage, postprocess_cb = makedemos("problems") # the relative path to docs/
+demopage, postprocess_cb = makedemos(page) # the relative path to docs/
 
 # 2. normal Documenter usage
 format = Documenter.HTML(prettyurls=get(ENV, "CI", nothing) == "true")
@@ -38,6 +20,6 @@ makedocs(format = format,
          sitename = "LeetCode")
 
 # 3. postprocess after makedocs
-postprocess_cb()
+# postprocess_cb() # FIXME: broken
 
 deploydocs(repo = "github.com/JuliaCN/LeetCode.jl.git")

--- a/docs/problems_raw/1.two-sum.md
+++ b/docs/problems_raw/1.two-sum.md
@@ -1,0 +1,45 @@
+---
+title: 1. Two Sum
+id: id1
+author: Tian Jun
+date: 2020-10-31
+app: leetcode
+lang: julia
+---
+https://leetcode.com/problems/two-sum/description/
+
+**Tags:** Array, Hash Table
+
+**Difficulty:** Easy
+Given an array of integers `nums` and an integer `target`, return _indices of
+the two numbers such that they add up to`target`_.
+
+You may assume that each input would have **_exactly_ one solution**, and you
+may not use the _same_ element twice.
+
+You can return the answer in any order.
+
+
+
+**Example 1:**
+            Input: nums = [2,7,11,15], target = 9    Output: [0,1]    Output: Because nums[0] + nums[1] == 9, we return [0, 1].    
+
+**Example 2:**
+            Input: nums = [3,2,4], target = 6    Output: [1,2]    
+
+**Example 3:**
+            Input: nums = [3,3], target = 6    Output: [0,1]    
+
+
+
+**Constraints:**
+
+  * `2 <= nums.length <= 103`
+  * `-109 <= nums[i] <= 109`
+  * `-109 <= target <= 109`
+  * **Only one valid answer exists.**
+
+
+**Idea:**
+
+**Code:**

--- a/docs/problems_raw/2.add-two-numbers.md
+++ b/docs/problems_raw/2.add-two-numbers.md
@@ -1,0 +1,46 @@
+---
+title: 2. Add Two Numbers
+id: id2
+author: Tian Jun
+date: 2020-10-31
+app: leetcode
+lang: julia
+---
+https://leetcode.com/problems/add-two-numbers/description/
+
+**Tags:** Linked List, Math
+
+**Difficulty:** Medium
+You are given two **non-empty** linked lists representing two non-negative
+integers. The digits are stored in **reverse order** , and each of their nodes
+contains a single digit. Add the two numbers and return the sum as a linked
+list.
+
+You may assume the two numbers do not contain any leading zero, except the
+number 0 itself.
+
+
+
+**Example 1:**
+
+![](https://assets.leetcode.com/uploads/2020/10/02/addtwonumber1.jpg)
+            Input: l1 = [2,4,3], l2 = [5,6,4]    Output: [7,0,8]    Explanation: 342 + 465 = 807.    
+
+**Example 2:**
+            Input: l1 = [0], l2 = [0]    Output: [0]    
+
+**Example 3:**
+            Input: l1 = [9,9,9,9,9,9,9], l2 = [9,9,9,9]    Output: [8,9,9,9,0,0,0,1]    
+
+
+
+**Constraints:**
+
+  * The number of nodes in each linked list is in the range `[1, 100]`.
+  * `0 <= Node.val <= 9`
+  * It is guaranteed that the list represents a number that does not have leading zeros.
+
+
+**Idea:**
+
+**Code:**

--- a/docs/problems_raw/3.longest-substring-without-repeating-characters.md
+++ b/docs/problems_raw/3.longest-substring-without-repeating-characters.md
@@ -1,0 +1,41 @@
+---
+title: 3. Longest Substring Without Repeating Characters
+id: id3
+author: Tian Jun
+date: 2020-10-31
+app: leetcode
+lang: julia
+---
+https://leetcode.com/problems/longest-substring-without-repeating-characters/description/
+
+**Tags:** Hash Table, Two Pointers, String, Sliding Window
+
+**Difficulty:** Medium
+Given a string `s`, find the length of the **longest substring** without
+repeating characters.
+
+
+
+**Example 1:**
+            Input: s = "abcabcbb"    Output: 3    Explanation: The answer is "abc", with the length of 3.    
+
+**Example 2:**
+            Input: s = "bbbbb"    Output: 1    Explanation: The answer is "b", with the length of 1.    
+
+**Example 3:**
+            Input: s = "pwwkew"    Output: 3    Explanation: The answer is "wke", with the length of 3.    Notice that the answer must be a substring, "pwke" is a subsequence and not a substring.    
+
+**Example 4:**
+            Input: s = ""    Output: 0    
+
+
+
+**Constraints:**
+
+  * `0 <= s.length <= 5 * 104`
+  * `s` consists of English letters, digits, symbols and spaces.
+
+
+**Idea:**
+
+**Code:**

--- a/docs/problems_raw/4.median-of-two-sorted-arrays.md
+++ b/docs/problems_raw/4.median-of-two-sorted-arrays.md
@@ -1,0 +1,50 @@
+---
+title: 4. Median of Two Sorted Arrays
+id: id4
+author: Tian Jun
+date: 2020-10-31
+app: leetcode
+lang: julia
+---
+https://leetcode.com/problems/median-of-two-sorted-arrays/description/
+
+**Tags:** Array, Binary Search, Divide and Conquer
+
+**Difficulty:** Hard
+Given two sorted arrays `nums1` and `nums2` of size `m` and `n` respectively,
+return **the median** of the two sorted arrays.
+
+**Follow up:** The overall run time complexity should be `O(log (m+n))`.
+
+
+
+**Example 1:**
+            Input: nums1 = [1,3], nums2 = [2]    Output: 2.00000    Explanation: merged array = [1,2,3] and median is 2.    
+
+**Example 2:**
+            Input: nums1 = [1,2], nums2 = [3,4]    Output: 2.50000    Explanation: merged array = [1,2,3,4] and median is (2 + 3) / 2 = 2.5.    
+
+**Example 3:**
+            Input: nums1 = [0,0], nums2 = [0,0]    Output: 0.00000    
+
+**Example 4:**
+            Input: nums1 = [], nums2 = [1]    Output: 1.00000    
+
+**Example 5:**
+            Input: nums1 = [2], nums2 = []    Output: 2.00000    
+
+
+
+**Constraints:**
+
+  * `nums1.length == m`
+  * `nums2.length == n`
+  * `0 <= m <= 1000`
+  * `0 <= n <= 1000`
+  * `1 <= m + n <= 2000`
+  * `-106 <= nums1[i], nums2[i] <= 106`
+
+
+**Idea:**
+
+**Code:**

--- a/src/problems_tmp/1.two-sum.jl
+++ b/src/problems_tmp/1.two-sum.jl
@@ -1,0 +1,18 @@
+# 我们可以在这里写一些解题思路
+#
+# 这些都会被当成是markdown处理
+
+
+## 而连续两个#会被当作注释处理
+function two_sum(nums::Vector{Int}, target::Int)::Union{Nothing,Tuple{Int,Int}}
+    seen = Dict{Int,Int}()
+    for (i, n) in enumerate(nums)
+        ## 这是一条注释
+        m = target - n
+        if haskey(seen, m)
+            return seen[m], i
+        else
+            seen[n] = i
+        end
+    end
+end

--- a/src/problems_tmp/2.add-two-numbers.jl
+++ b/src/problems_tmp/2.add-two-numbers.jl
@@ -1,0 +1,23 @@
+function add_two_numbers(l1::ListNode, l2::ListNode)::ListNode
+    carry = 0
+    fake_head = cur = ListNode()
+
+    while !isnothing(l1) || !isnothing(l2) || !iszero(carry)
+        v1, v2 = 0, 0
+
+        if !isnothing(l1)
+            v1 = val(l1)
+            l1 = next(l1)
+        end
+
+        if !isnothing(l2)
+            v2 = val(l2)
+            l2 = next(l2)
+        end
+
+        carry, v = divrem(v1 + v2 + carry, 10)
+        next!(cur, ListNode(v))
+        cur = next(cur)
+    end
+    return next(fake_head)
+end

--- a/src/problems_tmp/problems.jl
+++ b/src/problems_tmp/problems.jl
@@ -1,0 +1,5 @@
+for f in readdir(@__DIR__)
+    if f != splitdir(@__FILE__)[2]
+        include(f)
+    end
+end


### PR DESCRIPTION
这里演示一个简单的例子：

```text
docs/problems_raw/
├── 1.two-sum.md
├── 2.add-two-numbers.md
├── 3.longest-substring-without-repeating-characters.md
└── 4.median-of-two-sorted-arrays.md

src/problems_tmp/
├── 1.two-sum.jl
├── 2.add-two-numbers.jl
└── problems.jl
```

- 因为只有两个问题有解答，所以最终只会渲染两个结果
- `Check Solution` 这个标签点击就会自动跳转到解答的页面
- 生成的 md 模版似乎在换行方面还有些问题
- 侧边栏 solutions 应该被隐藏 (这应该是个bug https://github.com/johnnychen94/DemoCards.jl/issues/78)
- 测试结果（如果有的话）也会被加入到解答里，但现在测试结果的显示不是特别好

preview:

![image](https://user-images.githubusercontent.com/8684355/101205113-3b2ad300-36a8-11eb-91b7-97b321b8104d.png)

![image](https://user-images.githubusercontent.com/8684355/101205163-4978ef00-36a8-11eb-8d89-ef672b8af5a4.png)
